### PR TITLE
Scale the hover pattern on zoom

### DIFF
--- a/src/map/index.js
+++ b/src/map/index.js
@@ -88,6 +88,16 @@ export const initMap = container => {
         .selectAll("path")
         .style("stroke-width", `${1 / d3.event.transform.k}px`)
         .attr("transform", d3.event.transform);
+
+      svg
+        .selectAll("pattern")
+        .attr("width", `${10 / d3.event.transform.k}px`)
+        .attr("height", `${10 / d3.event.transform.k}px`);
+
+      svg
+        .selectAll("image")
+        .attr("width", `${10 / d3.event.transform.k}px`)
+        .attr("height", `${10 / d3.event.transform.k}px`);
     });
 
   geoPathGenerator = d3.geoPath().projection(projection);


### PR DESCRIPTION
This makes it so that when you zoom, the pattern scales down so it stays consistent, which is especially noticeable on the state maps.

![image](https://user-images.githubusercontent.com/1696495/57054928-8408e300-6c4c-11e9-8c37-30718bb9a3df.png)

It gets a little jittery but I think it's better.