### PR TITLE
Adding support for linear scale and defining number of buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,54 @@ To deploy:
 ```
 $ yarn run deploy
 ```
+
+# Setting up the Google Sheet
+
+In order for this to work, you need to set up your Google Sheet in a particular way.
+
+### Settings
+
+The first tab should be a settings tab. The following columns are required:
+
+- `Issue`: This is a key that will be used to link content from the content tab, e.g. `avr`.
+- `Issue label`: The longform version of the issue or data set, e.g. `Automatic voter registration`.
+- `Dataset`: One of `State`, `House`, or `NY State House`
+- `Tab`: The tab with the data on it.
+-
+
+These are optional columns that you can have for extra configuration:
+
+- `Title`: The title that will be displayed at the top of the map. If empty, it will default to `Support for [issue label]`.
+- `Min`: A decimal between 0 and 1. If empty, it will be 0.
+- `Max`: A decimal between 0 and 1. If empty, it will be 1.
+- `Scale`: The type of scale to use. Options:
+  - `red`: Linear scale from light red to dark red.
+  - `blue`: Linear scale from light blue to dark blue.
+  - `red-to-blue`: Divergent scale from red to blue.
+  - `blue-to-red`: Divergent scale from blue to red.
+  - `qualitative`: Red, yellow and green. Used for evaluating quality of policies.
+- `Buckets`: The number of buckets to divide the scale into. Defaults to 7. Options:
+  - `red` and `blue`: A number between 3 and 8.
+  - `red-to-blue` and `blue-to-red`: A number between 2 and 10.
+
+### Content
+
+The second tab of the sheet contains the content below the map. This tab should have these columns:
+
+- `Issue`: One of the keys from the settings `Issue` column.
+- `Content`: Markdown text.
+
+## Data sheets
+
+Every other sheet should correspond to a single dataset, where the number of the tab corresponds to the `Tab` value in the settings column.
+
+These sheets have the following required columns:
+
+- `Code`: This is what links data to a state or district. States use their FIPS code and districts use the state FIPS + district number. e.g. Arkansas 2nd district is `502` because Arkansas is `5` and district is `02`.
+- `Label`: This will be displayed. It can be a state abbreviation, full name, or whatever.
+
+Every other column on the sheet will be treated as a filter. It should have a decimal between 0 and 1 to show the percentage support for the issue.
+
+In order for a column label to show up as multiple words, use dashes: e.g. `independent-voters`.
+
+The sheet can have an optional `content` column that will be displayed in the details pane. Markdown is supported.

--- a/src/constants.js
+++ b/src/constants.js
@@ -31,6 +31,14 @@ export const nonFilters = [
 
 export const nonFilterPrefix = "na_";
 
+export const QUALITATIVE_SCALE = "qualitative";
+export const RED_SCALE = "red";
+export const BLUE_SCALE = "blue";
+export const DIVERGENT_SCALE = "red-to-blue";
+export const INVERTED_SCALE = "blue-to-red";
+export const DEFAULT_SCALE = DIVERGENT_SCALE;
+export const DEFAULT_BUCKETS = 7;
+
 export const qualKeys = [
   "no",
   "yes_low",
@@ -46,17 +54,6 @@ export const qualKeys = [
   "yes_high-no",
   "yes-high_yes-low",
   "yes-high_yes-high"
-];
-
-export const quantitativeColors = [
-  "#67001f",
-  "#b2182b",
-  "#d6604d",
-  "#f4a582",
-  "#92c5de",
-  "#4393c3",
-  "#2166ac",
-  "#053061"
 ];
 
 export const stateLabels = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { select, json } from "d3";
-import { prefix } from "./constants";
-import { buildMapURL, buildSheetsURL, parseRow, floatOrNull, makeLabel } from "./utils";
+import { prefix, DEFAULT_SCALE, DEFAULT_BUCKETS } from "./constants";
+import { buildMapURL, buildSheetsURL, parseRow, floatOrNull } from "./utils";
 import { getContent, showContent, initDom, toggleLoading } from "./content";
 import { removeDetails, initDetails } from "./map/details";
 import { initTooltip, removeTooltip } from "./map/tooltip";
@@ -138,14 +138,15 @@ const initDataMap = container => {
       try {
         const dataset = parseRow(entry.content.$t);
         const key = entry.title.$t;
-        const map_key = dataset.dataset.replace(/\s/g, "-").toLowerCase();
+        const mapKey = dataset.dataset.replace(/\s/g, "-").toLowerCase();
 
-        if (!loadedMaps[map_key]) {
-          fetchMap(map_key);
-          loadedMaps[map_key] = true;
+        if (!loadedMaps[mapKey]) {
+          fetchMap(mapKey);
+          loadedMaps[mapKey] = true;
         }
 
-        dataset.scaleType = dataset.scale || "quantitative";
+        dataset.scaleType = dataset.scale || DEFAULT_SCALE;
+        dataset.buckets = Number(dataset.buckets) || DEFAULT_BUCKETS;
 
         if (!Object.prototype.hasOwnProperty.call(datasets, key)) {
           datasets[key] = {};
@@ -157,12 +158,13 @@ const initDataMap = container => {
           datasets[key].defaultView = dataset.dataset.toLowerCase();
           datasets[key].issuekey = key;
           datasets[key].maps = [];
+          datasets[key].buckets = Number(dataset.buckets) || DEFAULT_BUCKETS;
           if (dataset.max) datasets[key].max = floatOrNull(dataset.max);
           if (dataset.min) datasets[key].min = floatOrNull(dataset.min);
         }
-        datasets[key][map_key] = dataset;
-        datasets[key].maps.push(map_key);
-        mapKeys[dataset.tab] = map_key;
+        datasets[key][mapKey] = dataset;
+        datasets[key].maps.push(mapKey);
+        mapKeys[dataset.tab] = mapKey;
       } catch (error) {
         console.error(
           `Could not import settings row ${entry.title.$t} ${entry.content.$t}, error:`

--- a/src/map/details.js
+++ b/src/map/details.js
@@ -7,7 +7,7 @@ import {
   notNA,
   getFullLabel
 } from "../utils";
-import { prefix, excludedKeys } from "../constants";
+import { prefix, excludedKeys, QUALITATIVE_SCALE } from "../constants";
 
 // Tooltip
 let details;
@@ -53,7 +53,7 @@ const qualitativeContent = data => {
 
 export const addDetails = d => {
   let content;
-  if (d.scaleType === "qualitative") {
+  if (d.scaleType === QUALITATIVE_SCALE) {
     content = qualitativeContent(d);
   } else {
     content = quantitativeContent(d);

--- a/src/map/scale.js
+++ b/src/map/scale.js
@@ -1,8 +1,10 @@
 import * as d3 from "d3";
-import { quantitativeColors, qualKeys } from "../constants";
+import { qualKeys, RED_SCALE, BLUE_SCALE, QUALITATIVE_SCALE, INVERTED_SCALE } from "../constants";
 
-export const getMapScale = (scaleType, domain) => {
-  if (scaleType === "qualitative") {
+export const getMapScale = (scaleType, domain, buckets) => {
+  const colorSchemeIndex = buckets + 1; // Account for 0-indexing
+
+  if (scaleType === QUALITATIVE_SCALE) {
     const qualMapScale = {};
     qualKeys.map(key => {
       qualMapScale[key] = `url(#${key})`;
@@ -10,10 +12,16 @@ export const getMapScale = (scaleType, domain) => {
 
     return value => qualMapScale[value];
   }
-  if (scaleType === "invertedquantitative") {
-    return d3.scaleQuantize(domain, quantitativeColors.reverse());
+  if (scaleType === INVERTED_SCALE) {
+    return d3.scaleQuantize(domain, d3.schemeRdBu[colorSchemeIndex].reverse());
   }
-  return d3.scaleQuantize(domain, quantitativeColors);
+  if (scaleType === BLUE_SCALE) {
+    return d3.scaleQuantize(domain, d3.schemeBlues[colorSchemeIndex]);
+  }
+  if (scaleType === RED_SCALE) {
+    return d3.scaleQuantize(domain, d3.schemeReds[colorSchemeIndex]);
+  }
+  return d3.scaleQuantize(domain, d3.schemeRdBu[colorSchemeIndex]);
 };
 
 export const getLegendScale = () => {

--- a/src/map/tooltip.js
+++ b/src/map/tooltip.js
@@ -1,6 +1,6 @@
 import { select } from "d3";
 import { formatAsPercentage, formatQualitativeScale, getFullLabel } from "../utils";
-import { prefix } from "../constants";
+import { prefix, QUALITATIVE_SCALE } from "../constants";
 
 // Tooltip
 let tooltip;
@@ -16,7 +16,7 @@ const getPosition = e => {
 
 const createTooltipContent = (data, filter, scale) => {
   let content = `<strong>${getFullLabel(data.label)}:</strong> `;
-  if (scale === "qualitative") {
+  if (scale === QUALITATIVE_SCALE) {
     content += `${formatQualitativeScale(data[filter], "long")}`;
   } else {
     content += `${formatAsPercentage(data[filter])}`;


### PR DESCRIPTION
This adds support for new scales and defining the number of buckets for each. The options for the `scale` column are:

- `red`
- `blue`
- `red-to-blue`
- `blue-to-red`
- `qualitative`

![image](https://user-images.githubusercontent.com/1696495/58681946-90ec2580-8323-11e9-816c-c87e7008dc37.png)

For `red` and `blue`, `buckets` can be any number between 3 and 8. 

For `red-to-blue` and `blue-to-red`, `buckets` can be between 2 and 10

`buckets` cannot be set for `qualitative`.

If `buckets` isn't set, it defaults to 7.

## Examples

![image](https://user-images.githubusercontent.com/1696495/58682192-78c8d600-8324-11e9-9307-6d5a4fe47f76.png)

![image](https://user-images.githubusercontent.com/1696495/58682362-1e7c4500-8325-11e9-83e6-802e04e3cf01.png)

![image](https://user-images.githubusercontent.com/1696495/58682203-83836b00-8324-11e9-80ce-ecb7b857fb29.png)

![image](https://user-images.githubusercontent.com/1696495/58682241-9dbd4900-8324-11e9-84d7-fecb554d85c6.png)





