### PR TITLE
Adding support for dynamic scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The first tab should be a settings tab. The following columns are required:
 These are optional columns that you can have for extra configuration:
 
 - `Title`: The title that will be displayed at the top of the map. If empty, it will default to `Support for [issue label]`.
+- `Legend label`: Override the label on the legend.
 - `Min`: A decimal between 0 and 1. If empty, it will be 0.
 - `Max`: A decimal between 0 and 1. If empty, it will be 1.
 - `Scale`: The type of scale to use. Options:

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ These are optional columns that you can have for extra configuration:
   - `blue`: Linear scale from light blue to dark blue.
   - `red-to-blue`: Divergent scale from red to blue.
   - `blue-to-red`: Divergent scale from blue to red.
+  - `red-inverted`: Linear scale from dark red to light red.
+  - `blue-inverted`: Linear scale from dark blue to light blue.
+  - `dynamic`: If min is at or above .5, light blue to dark blue. If max is at or below .5, dark red to light red. Otherwise dark red to dark blue.
+  - `dynamic-inverted`: If min is at or above .5, light blue to dark blue. If max is at or below .5, dark red to light red. Otherwise dark blue to dark red.
   - `qualitative`: Red, yellow and green. Used for evaluating quality of policies.
 - `Buckets`: The number of buckets to divide the scale into. Defaults to 7. Options:
   - `red` and `blue`: A number between 3 and 8.

--- a/src/constants.js
+++ b/src/constants.js
@@ -34,8 +34,12 @@ export const nonFilterPrefix = "na_";
 export const QUALITATIVE_SCALE = "qualitative";
 export const RED_SCALE = "red";
 export const BLUE_SCALE = "blue";
+export const INVERTED_RED_SCALE = "red-inverted";
+export const INVERTED_BLUE_SCALE = "blue-inverted";
 export const DIVERGENT_SCALE = "red-to-blue";
 export const INVERTED_SCALE = "blue-to-red";
+export const DYNAMIC_SCALE = "dynamic";
+export const INVERTED_DYNAMIC_SCALE = "dynamic-inverted";
 export const DEFAULT_SCALE = DIVERGENT_SCALE;
 export const DEFAULT_BUCKETS = 7;
 

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -7,7 +7,7 @@ import { prefix, nonFilters, nonFilterPrefix, QUALITATIVE_SCALE } from "../const
 import { addDetails, removeDetails } from "./details";
 import { buildQuantitativeLegend, buildQualitativeLegend } from "./legend";
 import { addTooltip, removeTooltip } from "./tooltip";
-import { getMapScale, getLegendScale } from "./scale";
+import { getMapScale, getLegendScale, getDomain, getDynamicDomain } from "./scale";
 import { addQualPatterns, toggleHoverPattern } from "./patterns";
 
 let filterContainer;
@@ -113,37 +113,12 @@ const drawFeatures = (pathGenerator, data) =>
     .attr("class", "feature")
     .on("click", handleClick);
 
-const updatePaths = (
-  paths,
-  filter,
-  { max: setMax, min: setMin, scaleType, legendLabel, buckets }
-) => {
+const updatePaths = (paths, filter, config) => {
   const data = paths
     .data()
     .map(d => d[filter])
     .filter(p => p);
-  const max = Math.max.apply(null, data);
-  const min = Math.min.apply(null, data);
-  const domain = [];
-
-  if (setMin) {
-    domain.push(setMin);
-  } else {
-    domain.push(
-      min < 0
-        ? min < -1
-          ? -100
-          : -1 // Assume equal distribution around zero
-        : 0 // Assume floor is zero
-    );
-  }
-  if (setMax) {
-    domain.push(setMax);
-  } else {
-    domain.push(max > 1 ? 100 : 1);
-  }
-
-  const scale = getMapScale(scaleType, domain, buckets);
+  const scale = getMapScale(config, data);
 
   paths
     .transition()
@@ -158,11 +133,11 @@ const updatePaths = (
       removeTooltip(d);
     });
 
-  if (scaleType === QUALITATIVE_SCALE) {
+  if (config.scaleType === QUALITATIVE_SCALE) {
     addQualPatterns(svg);
     buildQualitativeLegend(getLegendScale(), filter);
   } else {
-    buildQuantitativeLegend(scale, legendLabel);
+    buildQuantitativeLegend(scale, config.legendLabel);
   }
 };
 

--- a/src/map/scale.js
+++ b/src/map/scale.js
@@ -109,4 +109,3 @@ export const getLegendScale = () => {
   });
   return qualLegendScale;
 };
-// getDomain(min, max, setMin, setMax);

--- a/src/map/scale.js
+++ b/src/map/scale.js
@@ -8,7 +8,8 @@ import {
   DYNAMIC_SCALE,
   INVERTED_RED_SCALE,
   INVERTED_BLUE_SCALE,
-  INVERTED_DYNAMIC_SCALE
+  INVERTED_DYNAMIC_SCALE,
+  DIVERGENT_SCALE
 } from "../constants";
 
 export const getDomain = (data, setMin, setMax) => {
@@ -36,31 +37,32 @@ export const getDomain = (data, setMin, setMax) => {
 };
 
 export const getDynamicDomain = data => {
-  const min = Math.round(Math.min.apply(null, data) * 10) / 10;
-  const max = Math.round(Math.max.apply(null, data) * 10) / 10;
+  const min = Math.floor(Math.min.apply(null, data) * 10) / 10;
+  const max = Math.ceil(Math.max.apply(null, data) * 10) / 10;
   return [min, max];
 };
 
 export const getDynamicColorScheme = (domain, scaleType) => {
   if (scaleType === INVERTED_DYNAMIC_SCALE) {
-    if (domain[0] <= 0.5 && domain[1] <= 0.5) {
-      // If min and max are both below .5 go dark red to light red
+    if (domain[1] <= 0.5) {
+      // If min and max are both below .5 go dark blue to light blue
       return INVERTED_BLUE_SCALE;
     }
     if (domain[0] >= 0.5) {
-      // If min is over .5 go light blue to dark blue
+      // If min is over .5 go light red to dark red
       return RED_SCALE;
     }
-  } else {
-    if (domain[0] <= 0.5 && domain[1] <= 0.5) {
-      // If min and max are both below .5 go dark red to light red
-      return INVERTED_RED_SCALE;
-    }
-    if (domain[0] >= 0.5) {
-      // If min is over .5 go light blue to dark blue
-      return BLUE_SCALE;
-    }
+    return INVERTED_SCALE;
   }
+  if (domain[1] <= 0.5) {
+    // If min and max are both below .5 go dark red to light red
+    return INVERTED_RED_SCALE;
+  }
+  if (domain[0] >= 0.5) {
+    // If min is over .5 go light blue to dark blue
+    return BLUE_SCALE;
+  }
+  return DIVERGENT_SCALE;
 };
 
 export const getMapScale = ({ scaleType, buckets, setMin, setMax }, data) => {


### PR DESCRIPTION
## Dynamic 
### Min value >= 50%
![image](https://user-images.githubusercontent.com/1696495/59242030-e3003700-8bbe-11e9-84fe-311aa8f69590.png)

### Max value <= 50%
![image](https://user-images.githubusercontent.com/1696495/59242133-4b4f1880-8bbf-11e9-92b7-3ad20138b2de.png)

### Min below 50 and max above 50
Typical scale, going from red to blue

![image](https://user-images.githubusercontent.com/1696495/59242368-1ee7cc00-8bc0-11e9-8c39-2c558e1818ba.png)

## Dynamic - inverted
### Min value >= 50%
![image](https://user-images.githubusercontent.com/1696495/59242069-0c20c780-8bbf-11e9-87c6-158e09a11aa1.png)

### Max value <= 50%
![image](https://user-images.githubusercontent.com/1696495/59242115-412d1a00-8bbf-11e9-8fca-dccb28f3d944.png)

### Min below 50 and max above 50
Typical inverted scale:
![image](https://user-images.githubusercontent.com/1696495/59242395-3757e680-8bc0-11e9-8c00-67c4955ef4b2.png)

## Dynamic bucketing
Both `dynamic` and `dynamic-inverted` support specifying the number of buckets:
![image](https://user-images.githubusercontent.com/1696495/59242173-67eb5080-8bbf-11e9-8050-06f446bc2afc.png)

