### PR TITLE
Dynamic min and max setting

### DIFF
--- a/src/map/scale.js
+++ b/src/map/scale.js
@@ -36,10 +36,26 @@ export const getDomain = (data, setMin, setMax) => {
   return domain;
 };
 
-export const getDynamicDomain = data => {
+const getMinAndMax = data => {
   const min = Math.floor(Math.min.apply(null, data) * 10) / 10;
   const max = Math.ceil(Math.max.apply(null, data) * 10) / 10;
-  return [min, max];
+  return { min, max };
+};
+
+export const getDynamicDomain = data => {
+  // Calculate the dynamic range:
+  // 1. If all numbers are above or below .5, then just use the natural min and max from the dataset
+  // 2. If the min and max are on either side of .5, then take whichever is further from .5 and use
+  //    that to set the scale. So if the min is .4 and max is .8, adjust the domain to be [.2, .8]
+  const { min, max } = getMinAndMax(data);
+  if ((min <= 0.5 && max <= 0.5) || (min >= 0.5 && max >= 0.5)) {
+    return [min, max];
+  }
+  const maxFromHalf = max - 0.5;
+  const minFromHalf = 0.5 - min;
+  const newMax = maxFromHalf > minFromHalf ? max : 0.5 + minFromHalf;
+  const newMin = minFromHalf > maxFromHalf ? min : 0.5 - maxFromHalf;
+  return [newMin, newMax];
 };
 
 export const getDynamicColorScheme = (domain, scaleType) => {


### PR DESCRIPTION
If _all_ values are above 50%, then we just use the actual min and max from the dataset:

![image](https://user-images.githubusercontent.com/1696495/59566715-94b4c300-9018-11e9-9c09-0527b0797e74.png)

Similarly, if all values are below 50%, then we also use the actual min and max from the dataset.

But if the min is below 50% and the max is above 50%, then we check to see which is farther and use that to set the scale. So if the max is .8 (.3 above .5) and the min is .4 (.1 below .5), then we'll use the actual max (.8) but set the min to .2 (.5 - .3). 

![image](https://user-images.githubusercontent.com/1696495/59566746-1b69a000-9019-11e9-8a6a-fc6d30f1e9d6.png)
