### PR TITLE
Set midpoint to gray

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ These are optional columns that you can have for extra configuration:
 - `Scale`: The type of scale to use. Options:
   - `red`: Linear scale from light red to dark red.
   - `blue`: Linear scale from light blue to dark blue.
-  - `red-to-blue`: Divergent scale from red to blue.
-  - `blue-to-red`: Divergent scale from blue to red.
+  - `red-to-blue`: Divergent scale from red to blue. Must be an odd number; middle is automatically set to gray.
+  - `blue-to-red`: Divergent scale from blue to red. Must be an odd number; middle is automatically set to gray.
   - `red-inverted`: Linear scale from dark red to light red.
   - `blue-inverted`: Linear scale from dark blue to light blue.
   - `dynamic`: If min is at or above .5, light blue to dark blue. If max is at or below .5, dark red to light red. Otherwise dark red to dark blue.

--- a/src/map/legend.js
+++ b/src/map/legend.js
@@ -7,8 +7,13 @@ const size = 20;
 export const buildQuantitativeLegend = (scale, label) => {
   const legendSvg = d3.select(`.${prefix}legend`).select("svg");
   const stops = scale.thresholds().map(i => [i, scale(i)]);
-  d3.select(`.${prefix}legend-label`).text(label);
 
+  // Add the minimum bucket
+  // Necessary because usually D3 just shows the thresholds
+  const min = scale.domain()[0];
+  stops.splice(0, 0, [min, scale(min)]);
+
+  d3.select(`.${prefix}legend-label`).text(label);
   legendSvg.selectAll("*").remove();
 
   legendSvg

--- a/src/map/scale.js
+++ b/src/map/scale.js
@@ -42,6 +42,15 @@ const getMinAndMax = data => {
   return { min, max };
 };
 
+const findMiddlePoint = length => {
+  return Math.floor(length / 2);
+};
+
+const setMidpointToGray = scheme => {
+  scheme.splice(findMiddlePoint(scheme.length), 1, "#f7f7f7");
+  return scheme;
+};
+
 export const getDynamicDomain = data => {
   // Calculate the dynamic range:
   // 1. If all numbers are above or below .5, then just use the natural min and max from the dataset
@@ -82,7 +91,7 @@ export const getDynamicColorScheme = (domain, scaleType) => {
 };
 
 export const getMapScale = ({ scaleType, buckets, setMin, setMax }, data) => {
-  const colorSchemeIndex = buckets + 1; // Account for 0-indexing
+  const colorSchemeIndex = buckets; // Account for 0-indexing
   let domain = [];
   let colorScheme;
   if (scaleType === DYNAMIC_SCALE || scaleType === INVERTED_DYNAMIC_SCALE) {
@@ -101,7 +110,7 @@ export const getMapScale = ({ scaleType, buckets, setMin, setMax }, data) => {
     return value => qualMapScale[value];
   }
   if (colorScheme === INVERTED_SCALE) {
-    return d3.scaleQuantize(domain, d3.schemeRdBu[colorSchemeIndex].reverse());
+    return d3.scaleQuantize(domain, setMidpointToGray(d3.schemeRdBu[colorSchemeIndex].reverse()));
   }
   if (colorScheme === BLUE_SCALE) {
     return d3.scaleQuantize(domain, d3.schemeBlues[colorSchemeIndex]);
@@ -115,7 +124,7 @@ export const getMapScale = ({ scaleType, buckets, setMin, setMax }, data) => {
   if (colorScheme === INVERTED_BLUE_SCALE) {
     return d3.scaleQuantize(domain, d3.schemeBlues[colorSchemeIndex].reverse());
   }
-  return d3.scaleQuantize(domain, d3.schemeRdBu[colorSchemeIndex]);
+  return d3.scaleQuantize(domain, setMidpointToGray(d3.schemeRdBu[colorSchemeIndex]));
 };
 
 export const getLegendScale = () => {


### PR DESCRIPTION
This adds a couple changes to the scale and legend:

1. Override the middle value of any red-to-blue or blue-to-red to a light gray.
2. Add the `min - first threshold` bucket to the legend. This switches from showing a color swatch for each _threshold_ to showing one for each _bucket_.

![image](https://user-images.githubusercontent.com/1696495/62995850-40ab3c80-be17-11e9-93a8-686cb5e40c18.png)
