### PR TITLE
Fix broken content

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ const addMapSelector = (container, data, firstKey) => {
       window.location.hash = value;
       currentDataset = selected;
       build(selected.defaultTab);
-      addStateAndDistrictToggle(selected);
+      addStateAndDistrictToggle(container, selected);
       showContent(selected.issuekey);
     });
 
@@ -190,7 +190,7 @@ const initDataMap = container => {
     if (datasetKeys.length > 1 ) {
       addMapSelector(container, datasetKeys, firstKey);
     }
-    if( Object.values(mapKeys).length > 1 ) {
+    if (Object.values(mapKeys).length > 1) {
       addStateAndDistrictToggle(container, firstDataset);
     }
 

--- a/src/map/scale.js
+++ b/src/map/scale.js
@@ -42,15 +42,6 @@ const getMinAndMax = data => {
   return { min, max };
 };
 
-const findMiddlePoint = length => {
-  return Math.floor(length / 2);
-};
-
-const setMidpointToGray = scheme => {
-  scheme.splice(findMiddlePoint(scheme.length), 1, "#f7f7f7");
-  return scheme;
-};
-
 export const getDynamicDomain = data => {
   // Calculate the dynamic range:
   // 1. If all numbers are above or below .5, then just use the natural min and max from the dataset
@@ -94,6 +85,7 @@ export const getMapScale = ({ scaleType, buckets, setMin, setMax }, data) => {
   const colorSchemeIndex = buckets; // Account for 0-indexing
   let domain = [];
   let colorScheme;
+
   if (scaleType === DYNAMIC_SCALE || scaleType === INVERTED_DYNAMIC_SCALE) {
     domain = getDynamicDomain(data);
     colorScheme = getDynamicColorScheme(domain, scaleType);
@@ -110,7 +102,7 @@ export const getMapScale = ({ scaleType, buckets, setMin, setMax }, data) => {
     return value => qualMapScale[value];
   }
   if (colorScheme === INVERTED_SCALE) {
-    return d3.scaleQuantize(domain, setMidpointToGray(d3.schemeRdBu[colorSchemeIndex].reverse()));
+    return d3.scaleQuantize(domain, d3.schemeRdBu[colorSchemeIndex].reverse());
   }
   if (colorScheme === BLUE_SCALE) {
     return d3.scaleQuantize(domain, d3.schemeBlues[colorSchemeIndex]);
@@ -124,7 +116,8 @@ export const getMapScale = ({ scaleType, buckets, setMin, setMax }, data) => {
   if (colorScheme === INVERTED_BLUE_SCALE) {
     return d3.scaleQuantize(domain, d3.schemeBlues[colorSchemeIndex].reverse());
   }
-  return d3.scaleQuantize(domain, setMidpointToGray(d3.schemeRdBu[colorSchemeIndex]));
+
+  return d3.scaleQuantize(domain, d3.schemeRdBu[colorSchemeIndex]);
 };
 
 export const getLegendScale = () => {


### PR DESCRIPTION
This fixes an issue where the JS was crashing after changing the issue and so the content wouldn't show up.

It also rolls back some of the gray midpoint hacking because it turns out that by [adding the first bucket](https://github.com/pizza-to-the-polls/data-maps/blob/optional-gray/src/map/legend.js#L14) to the legend, we get an `#f7f7f7` bucket in the middle (if an odd number) by default.