### PR TITLE
Add embed, sharing by URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 dist
 .cache
+public/sheets

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <div style="padding: 30px 0; text-align: center; font-family: sans-serif; background: #eee;">
     <h4>Embed This Map!</h4>
     <p>Copy and paste this block of code and replace the <pre>data-spreadsheet-key</pre> on the div tag</p>
-    <textarea onclick="select(this)" readonly="true" style="resize: none; width: 400px; height: 160px">
+    <textarea onclick="select(this)" readonly="true" style="resize: none; max-width: 400px; width: 90%; height: 160px">
       <div class="data-progress-maps" data-spreadsheet-key="1loELb4aslMLnvzdU7mMz75iz11OyDblZZSRcINnukYk"></div><script>!function(d,w){if(!w.dfpMap){w.dfpMap="init";var i=d.createElement("script"),s=d.createElement("link");i.setAttribute("src","https://pizza-to-the-polls.github.io/data-maps/src/index.js"),s.setAttribute("href","https://pizza-to-the-polls.github.io/data-maps/styles/style.css"),s.setAttribute('rel','stylesheet'), s.setAttribute('type','text/css'),d.head.appendChild(i),d.head.appendChild(s)}}(document,window);</script>
     </textarea>
   </div>

--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
+    <!-- <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet"> -->
     <link rel="stylesheet" type="text/css" href="styles/style.scss">
   </head>
 <body>
 
-  <div class="data-progress-maps" data-spreadsheet-key="1loELb4aslMLnvzdU7mMz75iz11OyDblZZSRcINnukYk"></div>
+  <div class="data-progress-maps" data-spreadsheet-key="1loELb4aslMLnvzdU7mMz75iz11OyDblZZSRcINnukYk" data-start-key="opioids" data-start-map="house" data-start-tab="6"></div>
   <script src="src/index.js"></script>
 
   <div style="padding: 30px 0; text-align: center; font-family: sans-serif; background: #eee;">

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   </head>
 <body>
 
-  <div class="data-progress-maps" data-spreadsheet-key="1loELb4aslMLnvzdU7mMz75iz11OyDblZZSRcINnukYk" data-start-key="opioids" data-start-map="house" data-start-tab="6"></div>
+  <div class="data-progress-maps" data-spreadsheet-key="1loELb4aslMLnvzdU7mMz75iz11OyDblZZSRcINnukYk"></div>
   <script src="src/index.js"></script>
 
   <div style="padding: 30px 0; text-align: center; font-family: sans-serif; background: #eee;">

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "scripts": {
     "dev": "parcel index.html",
+    "dev-local": "LOCAL_DATA=true parcel index.html",
     "build": "parcel build index.html",
     "predeploy": "rm -rf dist && parcel build index.html src/index.js styles/style.scss --public-url https://pizza-to-the-polls.github.io/data-maps",
     "deploy": "gh-pages -d dist"

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -3,11 +3,12 @@ import marked from "marked";
 import fs from "fs";
 import { legendWidth, legendHeight, prefix } from "../constants";
 
-import { buildSheetsURL } from "../utils";
+import { buildSheetsURL, buildShareURL } from "../utils";
 
 let vis;
 let shareContainer;
 let shareImg;
+let shareInput;
 
 export const toggleLoading = (isLoading, elem = vis) => {
   if (isLoading) {
@@ -18,13 +19,21 @@ export const toggleLoading = (isLoading, elem = vis) => {
   }
 };
 
-export const toggleShare = (isOpen, dataURL) => {
+export const toggleShare = (isOpen, dataURL, sheetConfig) => {
   if (isOpen) {
-    shareImg.setAttribute("src", dataURL);
+    console.log(dataURL)
+    if( dataURL ) {
+      shareImg.setAttribute("src", dataURL);
+      shareImg.parentElement.style.display = 'block';
+    } else {
+      shareImg.parentElement.style.display = 'none';
+    }
+    shareInput.value = buildShareURL(sheetConfig)
     shareContainer.style.display = "flex";
   } else {
     shareImg.removeAttribute("src");
     shareContainer.style.display = "none";
+    shareInput.value = '';
   }
 };
 
@@ -79,18 +88,33 @@ export const initDom = outer => {
 
   // html2canvass only supported with promises
   if (typeof Promise !== "undefined" && Promise.toString().indexOf("[native code]") !== -1) {
+
+    const shareButtonContainer = document.createElement("div");
+    shareButtonContainer.className = `${prefix}share-button-container`;
+
+    shareInput = document.createElement("input");
+    shareInput.className = `${prefix}share-input`;
+    shareInput.onclick = (el) => { el.target.setSelectionRange(0, el.target.value.length) }
+
+    const shareLinkInstructions = document.createElement("p");
+    shareLinkInstructions.innerText = "Copy the link to share this view";
+
     const shareButton = document.createElement("button");
     shareButton.className = `${prefix}share-button`;
     shareButton.innerText = "Share Map";
-    map.appendChild(shareButton);
+    shareButtonContainer.appendChild(shareButton);
 
     const embedButton = document.createElement("button");
     embedButton.className = `${prefix}embed-button`;
     embedButton.innerText = "Embed Map";
-    map.appendChild(embedButton);
+    shareButtonContainer.appendChild(embedButton);
+
+    map.appendChild(shareButtonContainer);
 
     shareContainer = document.createElement("div");
     shareContainer.className = `${prefix}share-container`;
+
+    const shareImageContainer = document.createElement("div");
 
     const shareInstructions = document.createElement("p");
     shareInstructions.innerText = "Click to download the image.";
@@ -110,8 +134,11 @@ export const initDom = outer => {
         </body>
       `);
     };
-    shareContainer.appendChild(shareImg);
-    shareContainer.appendChild(shareInstructions);
+    shareImageContainer.appendChild(shareImg);
+    shareImageContainer.appendChild(shareInstructions);
+    shareContainer.appendChild(shareImageContainer);
+    shareContainer.appendChild(shareInput);
+    shareContainer.appendChild(shareLinkInstructions);
     shareContainer.appendChild(closeButton);
 
     // html2canvass will only load images with the same domain as the visited page

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -79,10 +79,15 @@ export const initDom = outer => {
 
   // html2canvass only supported with promises
   if (typeof Promise !== "undefined" && Promise.toString().indexOf("[native code]") !== -1) {
-    const sharebutton = document.createElement("button");
-    sharebutton.className = `${prefix}share-button`;
-    sharebutton.innerText = "Share Map";
-    map.appendChild(sharebutton);
+    const shareButton = document.createElement("button");
+    shareButton.className = `${prefix}share-button`;
+    shareButton.innerText = "Share Map";
+    map.appendChild(shareButton);
+
+    const embedButton = document.createElement("button");
+    embedButton.className = `${prefix}embed-button`;
+    embedButton.innerText = "Embed Map";
+    map.appendChild(embedButton);
 
     shareContainer = document.createElement("div");
     shareContainer.className = `${prefix}share-container`;

--- a/src/content/share.js
+++ b/src/content/share.js
@@ -1,0 +1,132 @@
+import { prefix } from "../constants";
+import { buildShareURL, buildEmbedCode } from "../utils"
+
+let shareContainer;
+let embedContainer;
+let shareImg;
+let shareInput;
+let embedBox;
+
+export const toggleEmbed = (isOpen, shareConfig) => {
+  if( isOpen ) {
+    embedContainer.style.display = "flex";
+    embedBox.value = buildEmbedCode(shareConfig);
+  } else {
+    embedContainer.style.display = "none";
+    embedBox.value = '';
+  }
+}
+
+export const toggleShare = (isOpen, dataURL, shareConfig) => {
+  if (isOpen) {
+    if( dataURL ) {
+      shareImg.setAttribute("src", dataURL);
+      shareImg.parentElement.style.display = 'block';
+    } else {
+      shareImg.parentElement.style.display = 'none';
+    }
+    shareInput.value = buildShareURL(shareConfig)
+    shareContainer.style.display = "flex";
+  } else {
+    shareImg.removeAttribute("src");
+    shareContainer.style.display = "none";
+    shareInput.value = '';
+  }
+};
+
+const addButtons = (map) => {
+  const shareButtonContainer = document.createElement("div");
+  shareButtonContainer.className = `${prefix}share-button-container`;
+
+  const shareButton = document.createElement("button");
+  shareButton.className = `${prefix}share-button`;
+  shareButton.innerText = "Share Map";
+  shareButtonContainer.appendChild(shareButton);
+
+  const embedButton = document.createElement("button");
+  embedButton.className = `${prefix}embed-button`;
+  embedButton.innerText = "Embed Map";
+  shareButtonContainer.appendChild(embedButton);
+
+  map.appendChild(shareButtonContainer);
+}
+
+const createShareContainer = () => {
+  shareInput = document.createElement("input");
+  shareInput.className = `${prefix}share-input`;
+  shareInput.onclick = (el) => { el.target.setSelectionRange(0, el.target.value.length) }
+
+  const shareLinkInstructions = document.createElement("p");
+  shareLinkInstructions.innerText = "Copy the link to share this view";
+
+  shareContainer = document.createElement("div");
+  shareContainer.className = `${prefix}share-container`;
+
+  const shareImageContainer = document.createElement("div");
+
+  const shareInstructions = document.createElement("p");
+  shareInstructions.innerText = "Click to download the image.";
+
+  const closeButton = document.createElement("button");
+  closeButton.innerText = "Back to Map";
+  closeButton.onclick = () => toggleShare(false);
+  shareImg = document.createElement("img");
+
+  // This is a weird one - you can't just open data-urls anymore
+  // so we need to open a window then write html to it :P
+  shareImg.onclick = event => {
+    const newWindow = window.open();
+    newWindow.document.write(`
+      <body style="background: #1c313a; margin: 0; padding: 0;">
+        <img src=${event.target.getAttribute("src")} style="width: 100%;">
+      </body>
+    `);
+  };
+  shareImageContainer.appendChild(shareImg);
+  shareImageContainer.appendChild(shareInstructions);
+  shareContainer.appendChild(shareImageContainer);
+  shareContainer.appendChild(shareInput);
+  shareContainer.appendChild(shareLinkInstructions);
+  shareContainer.appendChild(closeButton);
+
+  return shareContainer
+}
+
+const createEmbedContainer = () => {
+  embedBox = document.createElement("textarea");
+  embedBox.className = `${prefix}embed-box`;
+  embedBox.onclick = (el) => { el.target.setSelectionRange(0, el.target.value.length) }
+
+  const embedInstructions = document.createElement("p");
+  embedInstructions.innerText = "Copy the code to embed this map on your site.";
+
+  embedContainer = document.createElement("div");
+  embedContainer.className = `${prefix}share-container`;
+
+  const shareImageContainer = document.createElement("div");
+
+  const shareInstructions = document.createElement("p");
+  shareInstructions.innerText = "Click to download the image.";
+
+  const closeButton = document.createElement("button");
+  closeButton.innerText = "Back to Map";
+  closeButton.onclick = () => toggleEmbed(false);
+
+  embedContainer.appendChild(embedBox);
+  embedContainer.appendChild(embedInstructions);
+  embedContainer.appendChild(closeButton);
+
+  return embedContainer
+}
+
+const createShareContent = (map) => {
+  addButtons(map)
+
+
+  return {
+    shareContainer: createShareContainer(),
+    embedContainer: createEmbedContainer()
+  }
+}
+
+export default createShareContent;

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,9 @@ const mapKeys = {};
 const fetchMap = map => json(buildMapURL(map)).then(geojson => (maps[map] = geojson));
 
 const build = (tab, options, attempts) => {
+  options = options || {}
+  options.mapKey = mapKeys[tab]
+
   toggleLoading(true);
   if (!sheets[tab])
     return json(buildSheetsURL(tab, sheetKey)).then(raw => {

--- a/src/index.js
+++ b/src/index.js
@@ -21,8 +21,9 @@ const mapKeys = {};
 const fetchMap = map => json(buildMapURL(map)).then(geojson => (maps[map] = geojson));
 
 const build = (tab, options, attempts) => {
-  options = options || {}
-  options.mapKey = mapKeys[tab]
+  options = options || {};
+  options.mapKey = mapKeys[tab];
+  options.sheetKey = sheetKey;
 
   toggleLoading(true);
   if (!sheets[tab])

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -112,6 +112,7 @@ const drawFeatures = (pathGenerator, data) =>
     .enter()
     .append("path")
     .attr("d", pathGenerator)
+    .attr("id", d => `feature-num-${d.id}`)
     .attr("class", "feature")
     .on("click", handleClick);
 
@@ -165,7 +166,7 @@ const addFilters = (paths, filters, initialFilter, dataSetConfig) => {
       .text(makeLabel)
       .attr("value", d => d);
 
-    if( initialFilter ) filter.property('value', initialFilter)
+    if (initialFilter) filter.property("value", initialFilter);
   }
 };
 
@@ -213,9 +214,11 @@ const buildPathGenerator = (map, topoFeature) => {
 };
 
 // Draw the map
-export const drawMap = (stats, map, dataSetConfig, startFilter) => {
+export const drawMap = (stats, map, dataSetConfig, options) => {
+  const { firstFilter, firstFeature } = options || {};
   const topoFeature = topojson.feature(map, map.objects.features);
   const cleanStats = parseStats(stats);
+
   svg.selectAll("path").remove();
 
   const geoPathGenerator = buildPathGenerator(map, topoFeature);
@@ -223,7 +226,7 @@ export const drawMap = (stats, map, dataSetConfig, startFilter) => {
   const filters = Object.keys(cleanStats[0]).filter(
     key => !nonFilters.includes(key) && key.search(nonFilterPrefix) !== 0
   );
-  const initialFilter = filters.includes(startFilter) ? startFilter : filters[0];
+  const initialFilter = filters.includes(firstFilter) ? firstFilter : filters[0];
 
   toggleHoverPattern(svg, dataSetConfig.scaleType !== QUALITATIVE_SCALE);
 
@@ -240,4 +243,11 @@ export const drawMap = (stats, map, dataSetConfig, startFilter) => {
   addFilters(currentGeography, filters, initialFilter, dataSetConfig);
   updatePaths(currentGeography, initialFilter, dataSetConfig);
   createTable(cleanStats);
+
+  // For some reason the details don't load without a little delay
+  if (firstFeature) {
+    setTimeout(() => {
+      currentGeography.filter(d => d.id.toString() === firstFeature).each(handleClick);
+    }, 10);
+  }
 };

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -217,13 +217,14 @@ const buildPathGenerator = (map, topoFeature) => {
 
 // Draw the map
 export const drawMap = (stats, map, dataSetConfig, options) => {
-  const { firstFilter, firstFeature, mapKey } = options;
+  const { firstFilter, firstFeature, mapKey, sheetKey } = options;
   const topoFeature = topojson.feature(map, map.objects.features);
   const cleanStats = parseStats(stats);
 
   shareState.scaleType = dataSetConfig.scaleType;
   shareState.key = dataSetConfig.issuekey;
   shareState.map = mapKey;
+  shareState.sheetKey = sheetKey;
 
   svg.selectAll("path").remove();
 

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -13,6 +13,7 @@ import { addQualPatterns, toggleHoverPattern } from "./patterns";
 
 let filterContainer;
 let svg;
+let shareState = {};
 
 let geoPathGenerator;
 let svgWidth;
@@ -77,7 +78,7 @@ export const initMap = container => {
   svgHeight = +svg.attr("viewBox").split(" ")[3];
   const projection = d3.geoAlbersUsa().translate([svgWidth / 2, svgHeight / 2]);
   geoPathGenerator = d3.geoPath().projection(projection);
-  addShare();
+  addShare(shareState);
 
   document.addEventListener("click", event => {
     if (event.target.id === `${prefix}map-svg`) {
@@ -97,6 +98,7 @@ const addStatsToFeatures = (features, stats, scaleType, legendLabel) =>
 
 const handleClick = (d, key, allPaths) => {
   // d3.select('.selected-path')
+  shareState.feature = d.id;
   const thisPath = allPaths[key];
   d3.selectAll(".selected-path").classed("selected-path", false);
   thisPath.classList += " selected-path";
@@ -112,11 +114,11 @@ const drawFeatures = (pathGenerator, data) =>
     .enter()
     .append("path")
     .attr("d", pathGenerator)
-    .attr("id", d => `feature-num-${d.id}`)
     .attr("class", "feature")
     .on("click", handleClick);
 
 const updatePaths = (paths, filter, config) => {
+  shareState.filter = filter;
   const data = paths
     .data()
     .map(d => d[filter])
@@ -215,9 +217,13 @@ const buildPathGenerator = (map, topoFeature) => {
 
 // Draw the map
 export const drawMap = (stats, map, dataSetConfig, options) => {
-  const { firstFilter, firstFeature } = options || {};
+  const { firstFilter, firstFeature, mapKey } = options;
   const topoFeature = topojson.feature(map, map.objects.features);
   const cleanStats = parseStats(stats);
+
+  shareState.scaleType = dataSetConfig.scaleType;
+  shareState.key = dataSetConfig.issuekey;
+  shareState.map = mapKey;
 
   svg.selectAll("path").remove();
 

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -143,7 +143,7 @@ const updatePaths = (paths, filter, config) => {
   }
 };
 
-const addFilters = (paths, filters, dataSetConfig) => {
+const addFilters = (paths, filters, initialFilter, dataSetConfig) => {
   filterContainer.selectAll("*").remove();
   if (filters.length > 1) {
     filterContainer
@@ -164,6 +164,8 @@ const addFilters = (paths, filters, dataSetConfig) => {
       .append("option")
       .text(makeLabel)
       .attr("value", d => d);
+
+    if( initialFilter ) filter.property('value', initialFilter)
   }
 };
 
@@ -211,7 +213,7 @@ const buildPathGenerator = (map, topoFeature) => {
 };
 
 // Draw the map
-export const drawMap = (stats, map, dataSetConfig) => {
+export const drawMap = (stats, map, dataSetConfig, startFilter) => {
   const topoFeature = topojson.feature(map, map.objects.features);
   const cleanStats = parseStats(stats);
   svg.selectAll("path").remove();
@@ -221,6 +223,7 @@ export const drawMap = (stats, map, dataSetConfig) => {
   const filters = Object.keys(cleanStats[0]).filter(
     key => !nonFilters.includes(key) && key.search(nonFilterPrefix) !== 0
   );
+  const initialFilter = filters.includes(startFilter) ? startFilter : filters[0];
 
   toggleHoverPattern(svg, dataSetConfig.scaleType !== QUALITATIVE_SCALE);
 
@@ -234,7 +237,7 @@ export const drawMap = (stats, map, dataSetConfig) => {
     )
   );
 
-  addFilters(currentGeography, filters, dataSetConfig);
-  updatePaths(currentGeography, filters[0], dataSetConfig);
+  addFilters(currentGeography, filters, initialFilter, dataSetConfig);
+  updatePaths(currentGeography, initialFilter, dataSetConfig);
   createTable(cleanStats);
 };

--- a/src/map/share.js
+++ b/src/map/share.js
@@ -1,11 +1,17 @@
 import { select } from "d3";
 
 import html2canvas from "html2canvas";
-import { prefix } from "../constants";
+import { prefix, QUALITATIVE_SCALE } from "../constants";
 import { toggleLoading, toggleShare } from "../content";
+import { buildURL } from "../utils";
 
-export const addShare = () => {
+export const addShare = (shareState) => {
+
   select(`.${prefix}share-button`).on("click", () => {
+    if( shareState.scaleType === QUALITATIVE_SCALE ) {
+      return toggleShare(true, false, shareState)
+    }
+
     const elem = document.querySelector(`.${prefix}vis`);
     const parent = elem.parentNode;
     const copy = document.querySelector(`.${prefix}vis`).cloneNode(true);
@@ -33,9 +39,10 @@ export const addShare = () => {
       mapSVG.removeAttribute("width");
       mapSVG.removeAttribute("height");
       toggleLoading(false);
-      toggleShare(true, canvas.toDataURL("image/png"));
+      toggleShare(true, canvas.toDataURL("image/png"), shareState);
       elem.classList.remove("generating-screenshot");
       if( legendSVG ) {
+        legendSVG.removeAttribute('width');
         legendSVG.setAttribute("viewBox", "0 0 320 40");
       }
       parent.removeChild(copy);

--- a/src/map/share.js
+++ b/src/map/share.js
@@ -2,12 +2,21 @@ import { select } from "d3";
 
 import html2canvas from "html2canvas";
 import { prefix, QUALITATIVE_SCALE } from "../constants";
-import { toggleLoading, toggleShare } from "../content";
+import { toggleLoading, toggleShare, toggleEmbed } from "../content";
 import { buildURL } from "../utils";
 
 export const addShare = (shareState) => {
 
+  select(`.${prefix}embed-button`).on("click", () => toggleEmbed(true, shareState))
+
   select(`.${prefix}share-button`).on("click", () => {
+
+    // html2canvass only supported with promises
+    if (typeof Promise !== "undefined" && Promise.toString().indexOf("[native code]") === -1) {
+      return toggleShare(true, false, shareState)
+    }
+
+    // html2canvass doesn't support dynamic images used in qualitative scale
     if( shareState.scaleType === QUALITATIVE_SCALE ) {
       return toggleShare(true, false, shareState)
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -78,3 +78,62 @@ export const getFullLabel = value => {
 
   return stateLabels[value] || value;
 };
+
+export const getMapConfig = (datasets, { startKey, startMap, startFilter }) => {
+  const datasetKeys = Object.keys(datasets);
+
+  const [hashKey, hashMap, hashFilter] = (window.location.hash ? window.location.hash.split("#")[1].split("|") : []);
+
+  if (datasetKeys.includes(hashKey)) {
+    // If the hash matches a dataset and contains a map - return the map
+    // If the hash matches a dataset without a map - return the defaults
+
+    const hashedDataSet = datasets[hashKey];
+    const hashedViewSet = datasets[hashKey][hashMap];
+
+    return {
+      datasetKeys,
+      firstKey: hashKey,
+      firstDataset: hashedDataSet,
+      firstMap: hashedViewSet
+        ? hashMap
+        : hashedDataSet.defaultMap,
+      firstTab: hashedViewSet
+        ? hashedViewSet.tab
+        : hashedDataSet.defaultTab,
+      firstFilter: hashFilter,
+    };
+  }
+
+  if(datasetKeys.includes(startKey)) {
+    // If the data attr matches a dataset and contains a map - return the map
+    // If the data attr matches a dataset without a map - return the defaults
+
+    const startDataSet = datasets[startKey]
+    const startViewSet = datasets[startKey][startMap]
+
+    return {
+      datasetKeys,
+      firstKey: startKey,
+      firstDataset: startDataSet,
+      firstMap: startViewSet
+        ? startMap
+        : startDataSet.defaultMap,
+      firstTab: startViewSet
+        ? startViewSet.tab
+        : startDataSet.defaultTab,
+      firstFilter: startFilter
+    };
+  }
+
+  const defaultKey = datasetKeys[0];
+  const defaultDataSet = datasets[defaultKey];
+
+  return {
+    datasetKeys,
+    firstKey: defaultKey,
+    firstDataset: defaultDataSet,
+    firstMap: defaultDataSet.defaultMap,
+    firstTab: defaultDataSet.defaultTab,
+  };
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,9 @@
 import { sheetsBaseUrl, rootURL, stateLabels } from "./constants";
 
 export const buildSheetsURL = (tab, sheetsID) =>
-  `${sheetsBaseUrl}/${sheetsID}/${tab}/public/basic?alt=json`;
+  process.env.LOCAL_DATA === "true"
+    ? `${rootURL}/sheets/${sheetsID}/${tab}.json`
+    : `${sheetsBaseUrl}/${sheetsID}/${tab}/public/basic?alt=json`;
 
 export const buildMapURL = map => `${rootURL}${map}.json`;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,10 +79,12 @@ export const getFullLabel = value => {
   return stateLabels[value] || value;
 };
 
-export const getMapConfig = (datasets, { startKey, startMap, startFilter }) => {
+export const getMapConfig = (datasets, { startKey, startMap, startFilter, startFeature }) => {
   const datasetKeys = Object.keys(datasets);
 
-  const [hashKey, hashMap, hashFilter] = (window.location.hash ? window.location.hash.split("#")[1].split("|") : []);
+  const [hashKey, hashMap, hashFilter, hashFeature] = (window.location.hash ? window.location.hash.split("#")[1].split("|") : []);
+
+  const firstFeature = hashFeature || startFeature;
 
   if (datasetKeys.includes(hashKey)) {
     // If the hash matches a dataset and contains a map - return the map
@@ -102,15 +104,19 @@ export const getMapConfig = (datasets, { startKey, startMap, startFilter }) => {
         ? hashedViewSet.tab
         : hashedDataSet.defaultTab,
       firstFilter: hashFilter,
+      firstFeature
     };
   }
 
-  if(datasetKeys.includes(startKey)) {
+  const defaultKey = datasetKeys[0];
+  const defaultDataSet = datasets[defaultKey];
+
+  if(datasetKeys.includes(startKey) || defaultDataSet[startMap]) {
     // If the data attr matches a dataset and contains a map - return the map
     // If the data attr matches a dataset without a map - return the defaults
 
-    const startDataSet = datasets[startKey]
-    const startViewSet = datasets[startKey][startMap]
+    const startDataSet = datasets[startKey] || defaultDataSet;
+    const startViewSet = startDataSet[startMap]
 
     return {
       datasetKeys,
@@ -122,12 +128,11 @@ export const getMapConfig = (datasets, { startKey, startMap, startFilter }) => {
       firstTab: startViewSet
         ? startViewSet.tab
         : startDataSet.defaultTab,
-      firstFilter: startFilter
+      firstFilter: startFilter,
+      firstFeature
     };
   }
 
-  const defaultKey = datasetKeys[0];
-  const defaultDataSet = datasets[defaultKey];
 
   return {
     datasetKeys,
@@ -135,5 +140,6 @@ export const getMapConfig = (datasets, { startKey, startMap, startFilter }) => {
     firstDataset: defaultDataSet,
     firstMap: defaultDataSet.defaultMap,
     firstTab: defaultDataSet.defaultTab,
+    firstFeature
   };
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -142,3 +142,28 @@ export const buildShareURL = shareState =>
     document.location.toString().split("#")[0],
     [shareState.key, shareState.map, shareState.filter, shareState.feature].filter(e => e).join("|")
   ].join("#");
+
+export const buildEmbedCode = shareState => {
+  const embedDiv = document.createElement('div');
+  embedDiv.class="data-progress-maps"
+
+  embedDiv.setAttribute('data-spreadsheet-key', shareState.sheetKey)
+  embedDiv.setAttribute('data-start-key', shareState.key)
+  embedDiv.setAttribute('data-start-map', shareState.map)
+  embedDiv.setAttribute('data-start-filter', shareState.filter)
+  embedDiv.setAttribute('data-start-feature', shareState.feature)
+
+
+  const embedScript = [
+    '<script>!function(d,w){if(!w.dfpMap){w.dfpMap="init";',
+    'var i=d.createElement("script"),s=d.createElement("link");',
+    'i.setAttribute("src","https://pizza-to-the-polls.github.io',
+    '/data-maps/src/index.js"),s.setAttribute("href",',
+    '"https://pizza-to-the-polls.github.io/data-maps/styles/style.css"),',
+    's.setAttribute("rel","stylesheet"), s.setAttribute("type","text/css")',
+    ',d.head.appendChild(i),d.head.appendChild(s)}}(document,window);</script>'
+  ].join('')
+
+
+  return `${embedDiv.outerHTML}${embedScript}`
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,7 +82,9 @@ export const getFullLabel = value => {
 export const getMapConfig = (datasets, { startKey, startMap, startFilter, startFeature }) => {
   const datasetKeys = Object.keys(datasets);
 
-  const [hashKey, hashMap, hashFilter, hashFeature] = (window.location.hash ? window.location.hash.split("#")[1].split("|") : []);
+  const [hashKey, hashMap, hashFilter, hashFeature] = window.location.hash
+    ? window.location.hash.split("#")[1].split("|")
+    : [];
 
   const firstFeature = hashFeature || startFeature;
 
@@ -97,12 +99,8 @@ export const getMapConfig = (datasets, { startKey, startMap, startFilter, startF
       datasetKeys,
       firstKey: hashKey,
       firstDataset: hashedDataSet,
-      firstMap: hashedViewSet
-        ? hashMap
-        : hashedDataSet.defaultMap,
-      firstTab: hashedViewSet
-        ? hashedViewSet.tab
-        : hashedDataSet.defaultTab,
+      firstMap: hashedViewSet ? hashMap : hashedDataSet.defaultMap,
+      firstTab: hashedViewSet ? hashedViewSet.tab : hashedDataSet.defaultTab,
       firstFilter: hashFilter,
       firstFeature
     };
@@ -111,28 +109,23 @@ export const getMapConfig = (datasets, { startKey, startMap, startFilter, startF
   const defaultKey = datasetKeys[0];
   const defaultDataSet = datasets[defaultKey];
 
-  if(datasetKeys.includes(startKey) || defaultDataSet[startMap]) {
+  if (datasetKeys.includes(startKey) || defaultDataSet[startMap]) {
     // If the data attr matches a dataset and contains a map - return the map
     // If the data attr matches a dataset without a map - return the defaults
 
     const startDataSet = datasets[startKey] || defaultDataSet;
-    const startViewSet = startDataSet[startMap]
+    const startViewSet = startDataSet[startMap];
 
     return {
       datasetKeys,
       firstKey: startKey,
       firstDataset: startDataSet,
-      firstMap: startViewSet
-        ? startMap
-        : startDataSet.defaultMap,
-      firstTab: startViewSet
-        ? startViewSet.tab
-        : startDataSet.defaultTab,
+      firstMap: startViewSet ? startMap : startDataSet.defaultMap,
+      firstTab: startViewSet ? startViewSet.tab : startDataSet.defaultTab,
       firstFilter: startFilter,
       firstFeature
     };
   }
-
 
   return {
     datasetKeys,
@@ -143,3 +136,9 @@ export const getMapConfig = (datasets, { startKey, startMap, startFilter, startF
     firstFeature
   };
 };
+
+export const buildShareURL = shareState =>
+  [
+    document.location.toString().split("#")[0],
+    [shareState.key, shareState.map, shareState.filter, shareState.feature].filter(e => e).join("|")
+  ].join("#");

--- a/styles/map.scss
+++ b/styles/map.scss
@@ -30,7 +30,8 @@ $details-color: $gray1;
     left: -9999px;
     top: -9999px;
 
-    .#{$prefix}share-button {
+    .#{$prefix}share-button,
+    .#{$prefix}embed-button {
       display: none;
     }
 
@@ -267,19 +268,28 @@ span.#{$prefix}legend-label {
   }
 }
 
-.#{$prefix}share-button {
+.#{$prefix}share-button,
+.#{$prefix}embed-button {
   z-index: 4;
-  background-color: $blue;
+  background-color: $gray4;
   color: #fff;
   border: none;
   margin: 5px;
 
   @media screen and (min-width: 600px) {
     position: absolute;
-    right: 4px;
     bottom: 10px;
     top: inherit;
     right: 10px;
+  }
+}
+.#{$prefix}embed-button {
+  background-color: $blue;
+  display: none;
+
+  @media screen and (min-width: 600px) {
+    right: 120px;
+    display: block;
   }
 }
 .#{$prefix}map-url {

--- a/styles/map.scss
+++ b/styles/map.scss
@@ -280,7 +280,7 @@ span.#{$prefix}legend-label {
   max-width: 60%;
   width: 100%;
   min-width: 300px;
-  margin: 30px auto;
+  margin: 14px auto;
   height: 40px;
   font-size: 1.5rem;
   background-color: transparent;

--- a/styles/map.scss
+++ b/styles/map.scss
@@ -276,7 +276,6 @@ span.#{$prefix}legend-label {
     right: 10px;
   }
 }
-
 .#{$prefix}share-input {
   max-width: 60%;
   width: 100%;
@@ -293,7 +292,22 @@ span.#{$prefix}legend-label {
     outline: none;
   }
 }
-
+.#{$prefix}embed-box {
+  max-width: 60%;
+  width: 100%;
+  min-width: 300px;
+  margin: 30px auto;
+  height: 200px;
+  font-family: monospace;
+  background-color: white;
+  font-size: 1.1rem;
+  resize: none;
+  border: none;
+  color: $gray1;
+  &:focus {
+    outline: none;
+  }
+}
 .#{$prefix}share-button,
 .#{$prefix}embed-button {
   z-index: 4;

--- a/styles/map.scss
+++ b/styles/map.scss
@@ -30,8 +30,7 @@ $details-color: $gray1;
     left: -9999px;
     top: -9999px;
 
-    .#{$prefix}share-button,
-    .#{$prefix}embed-button {
+    .#{$prefix}share-button-container {
       display: none;
     }
 
@@ -268,14 +267,8 @@ span.#{$prefix}legend-label {
   }
 }
 
-.#{$prefix}share-button,
-.#{$prefix}embed-button {
+.#{$prefix}share-button-container {
   z-index: 4;
-  background-color: $gray4;
-  color: #fff;
-  border: none;
-  margin: 5px;
-
   @media screen and (min-width: 600px) {
     position: absolute;
     bottom: 10px;
@@ -283,12 +276,43 @@ span.#{$prefix}legend-label {
     right: 10px;
   }
 }
+
+.#{$prefix}share-input {
+  max-width: 60%;
+  width: 100%;
+  min-width: 300px;
+  margin: 30px auto;
+  height: 40px;
+  font-size: 1.5rem;
+  background-color: transparent;
+  border: none;
+  color: white;
+  text-align: center;
+  text-decoration: underline;
+  &:focus {
+    outline: none;
+  }
+}
+
+.#{$prefix}share-button,
+.#{$prefix}embed-button {
+  z-index: 4;
+  background-color: $gray4;
+  color: #fff;
+  border: none;
+  margin: 5px;
+  width: 120px;
+}
+.#{$prefix}share-container p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: $gray3;
+}
 .#{$prefix}embed-button {
   background-color: $blue;
   display: none;
 
   @media screen and (min-width: 600px) {
-    right: 120px;
     display: block;
   }
 }

--- a/styles/share.scss
+++ b/styles/share.scss
@@ -29,7 +29,7 @@
     width: 20%;
     min-width: 160px;
     text-align: center;
-    margin: 30px auto 0;
+    margin: 14px auto 0;
   }
   z-index: 20;
 }


### PR DESCRIPTION
A few big changes additions:

 * Added an offline mode if you save a sheet to your `public/sheets` directory and run `yarn dev-local`
 * Allow sharing URLS with issue key, map, filter, and selected feature (as if you clicked on it)
 * Allows data attributes to drive issue key, map, filter, and selected feature (as if you clicked on it)
 * Share button includes a link for sharing a particular view
 * Toggle off image share for qualitative maps (it doesn't work)
 * Embed button shows a textarea with div attributes all set, for easy embedding
